### PR TITLE
Quickfix dynamodb shortlink field and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,5 +142,5 @@ The service is configured by Environment Variable:
 | AWS_SESSION_TOKEN | None | AWS_SESSION_TOKEN                              |
 | ALLOWED_DOMAINS | 'admin.ch,swisstopo.ch,bgdi.ch' | A comma separated list of allowed domains names |
 | ALLOWED_HOSTS | 'api.geo.admin.ch,api3.geo.admin.ch' | a comma separated list of allowed hostnames |
-| AWS_DYNAMODB_TABLE_NAME | 'shortlinks_dev' | The dynamodb table name |
+| AWS_DYNAMODB_TABLE_NAME | 'shortlinks_test' | The dynamodb table name |
 | AWS_DYNAMODB_TABLE_REGION | 'eu-central-1' | The AWS region in which the table is hosted. |

--- a/README.md
+++ b/README.md
@@ -142,5 +142,5 @@ The service is configured by Environment Variable:
 | AWS_SESSION_TOKEN | None | AWS_SESSION_TOKEN                              |
 | ALLOWED_DOMAINS | 'admin.ch,swisstopo.ch,bgdi.ch' | A comma separated list of allowed domains names |
 | ALLOWED_HOSTS | 'api.geo.admin.ch,api3.geo.admin.ch' | a comma separated list of allowed hostnames |
-| AWS_DYNAMODB_TABLE_NAME | 'shorturl' | The dynamodb table name |
+| AWS_DYNAMODB_TABLE_NAME | 'shortlinks_dev' | The dynamodb table name |
 | AWS_DYNAMODB_TABLE_REGION | 'eu-central-1' | The AWS region in which the table is hosted. |

--- a/app/helpers/checks.py
+++ b/app/helpers/checks.py
@@ -87,7 +87,7 @@ def check_params(scheme, host, url, base_path):
     return base_url
 
 
-def check_and_get_url_short(table, url):
+def check_and_get_shortlinks_id(table, url):
     """
     * Quick summary of the function *
 
@@ -114,7 +114,7 @@ def check_and_get_url_short(table, url):
         KeyConditionExpression=Key('url').eq(url),
     )
     try:
-        return response['Items'][0]['url_short']
+        return response['Items'][0]['shortlinks_id']
     except IndexError:
         logger.debug("The following url ( %s ) was not found in dynamodb", url)
         return None

--- a/app/helpers/urls.py
+++ b/app/helpers/urls.py
@@ -7,7 +7,7 @@ import boto3.exceptions as boto3_exc
 from boto3.dynamodb.conditions import Key
 from flask import abort
 
-from app.helpers.checks import check_and_get_url_short
+from app.helpers.checks import check_and_get_shortlinks_id
 from app.helpers.response_generation import make_error_msg
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ def create_url(table, url):
         now = time.localtime()
         table.put_item(
             Item={
-                'url_short': shortened_url,
+                'shortlinks_id': shortened_url,
                 'url': url,
                 'timestamp': time.strftime('%Y-%m-%d %X', now),
                 'epoch': str(time.gmtime())
@@ -89,7 +89,7 @@ def fetch_url(table, url_id, url_root):
 
     try:
         response = table.query(
-            IndexName='shortlinkID', KeyConditionExpression=Key('url_short').eq(url_id)
+            IndexName='ShortlinksIndex', KeyConditionExpression=Key('shortlinks_id').eq(url_id)
         )
         url = response['Items'][0]['url'] if len(response['Items']) > 0 else None
 
@@ -125,7 +125,7 @@ def add_item(table, url):
     :param url: the url we want to shorten
     :return: the shortened url id
     """
-    shortened_url = check_and_get_url_short(table, url)
+    shortened_url = check_and_get_shortlinks_id(table, url)
     if shortened_url is None:
         shortened_url = create_url(table, url)
     return shortened_url

--- a/service_config.py
+++ b/service_config.py
@@ -8,6 +8,6 @@ value and an environment value to override it.
 """
 allowed_domains = os.environ.get('ALLOWED_DOMAINS', 'admin.ch,swisstopo.ch,bgdi.ch').split(',')
 allowed_hosts = os.environ.get('ALLOWED_HOSTS', 'api.geo.admin.ch,api3.geo.admin.ch').split(',')
-aws_table_name = os.environ.get('AWS_DYNAMODB_TABLE_NAME', 'shortlinks_dev')
+aws_table_name = os.environ.get('AWS_DYNAMODB_TABLE_NAME', 'shortlinks_test')
 aws_region = os.environ.get('AWS_DYNAMODB_TABLE_REGION', 'eu-central-1')
 allowed_domains_pattern = re.compile(r"^.*\.admin\.ch|.*\.swisstopo\.cloud|.*\.bgdi\.ch$")

--- a/service_config.py
+++ b/service_config.py
@@ -8,6 +8,6 @@ value and an environment value to override it.
 """
 allowed_domains = os.environ.get('ALLOWED_DOMAINS', 'admin.ch,swisstopo.ch,bgdi.ch').split(',')
 allowed_hosts = os.environ.get('ALLOWED_HOSTS', 'api.geo.admin.ch,api3.geo.admin.ch').split(',')
-aws_table_name = os.environ.get('AWS_DYNAMODB_TABLE_NAME', 'shorturl')
+aws_table_name = os.environ.get('AWS_DYNAMODB_TABLE_NAME', 'shortlinks_dev')
 aws_region = os.environ.get('AWS_DYNAMODB_TABLE_REGION', 'eu-central-1')
 allowed_domains_pattern = re.compile(r"^.*\.admin\.ch|.*\.swisstopo\.cloud|.*\.bgdi\.ch$")

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -40,7 +40,7 @@ class TestDynamoDb(unittest.TestCase):
         self.connection = boto3.resource('dynamodb', region)
         logger.warning("Right before table creation")
         self.connection.create_table(
-            TableName='shorturl',
+            TableName='shortlinks_test',
             AttributeDefinitions=[
                     {
                         'AttributeName': 'url',
@@ -95,7 +95,7 @@ class TestDynamoDb(unittest.TestCase):
                     'WriteCapacityUnits': 123
                 }
         )
-        self.table = self.connection.Table('shorturl')
+        self.table = self.connection.Table('shortlinks_test')
         for url in self.valid_urls_list:
             uuid = (create_url(self.table, url))
             self.uuid_to_url_dict[uuid] = url

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -10,7 +10,7 @@ from werkzeug.exceptions import HTTPException
 
 from app import app
 from app.helpers.checks import check_params
-from app.helpers.checks import check_and_get_url_short
+from app.helpers.checks import check_and_get_shortlinks_id
 from app.helpers.urls import add_item
 from app.helpers.urls import create_url
 from app.helpers.urls import fetch_url
@@ -47,14 +47,14 @@ class TestDynamoDb(unittest.TestCase):
                         'AttributeType': 'S'
                     },
                     {
-                        'AttributeName': 'url_short',
+                        'AttributeName': 'shortlinks_id',
                         'AttributeType': 'S'
                     }
 
                 ],
             KeySchema=[
                 {
-                        'AttributeName': 'url_short',
+                        'AttributeName': 'shortlinks_id',
                         'KeyType': 'HASH'
                     },
                 {
@@ -73,14 +73,14 @@ class TestDynamoDb(unittest.TestCase):
                         ],
                         'Projection': {
                             'ProjectionType': 'INCLUDE',
-                            'NonKeyAttributes': ['url_short']
+                            'NonKeyAttributes': ['shortlinks_id']
                         }
                     },
                     {
-                        'IndexName': 'shortlinkID',
+                        'IndexName': 'ShortlinksIndex',
                         'KeySchema': [
                             {
-                                'AttributeName': 'url_short',
+                                'AttributeName': 'shortlinks_id',
                                 'KeyType': 'HASH'
                             }
                         ],
@@ -175,15 +175,15 @@ class TestDynamoDb(unittest.TestCase):
                 self.assertEqual(http_error.exception.code, 400)
 
     @mock_dynamodb2
-    def test_check_and_get_url_short(self):
+    def test_check_and_get_shortlinks_id(self):
         self.setup()
         for uuid, url in self.uuid_to_url_dict.items():
-            self.assertEqual(check_and_get_url_short(self.table, url), uuid)
+            self.assertEqual(check_and_get_shortlinks_id(self.table, url), uuid)
 
     @mock_dynamodb2
-    def test_check_and_get_url_short_non_existent(self):
+    def test_check_and_get_shortlinks_id_non_existent(self):
         self.setup()
-        self.assertEqual(check_and_get_url_short(self.table, "http://non.existent.url.ch"), None)
+        self.assertEqual(check_and_get_shortlinks_id(self.table, "http://non.existent.url.ch"), None)
 
     @mock_dynamodb2
     def test_add_item(self):

--- a/tests/unit_tests/test_routes.py
+++ b/tests/unit_tests/test_routes.py
@@ -49,14 +49,14 @@ class TestRoutes(unittest.TestCase):
                     'AttributeType': 'S'
                 },
                 {
-                    'AttributeName': 'url_short',
+                    'AttributeName': 'shortlinks_id',
                     'AttributeType': 'S'
                 }
 
             ],
             KeySchema=[
                 {
-                    'AttributeName': 'url_short',
+                    'AttributeName': 'shortlinks_id',
                     'KeyType': 'HASH'
                 },
                 {
@@ -75,14 +75,14 @@ class TestRoutes(unittest.TestCase):
                     ],
                     'Projection': {
                         'ProjectionType': 'INCLUDE',
-                        'NonKeyAttributes': ['url_short']
+                        'NonKeyAttributes': ['shortlinks_id']
                     }
                 },
                 {
-                    'IndexName': 'shortlinkID',
+                    'IndexName': 'ShortlinksIndex',
                     'KeySchema': [
                         {
-                            'AttributeName': 'url_short',
+                            'AttributeName': 'shortlinks_id',
                             'KeyType': 'HASH'
                         }
                     ],

--- a/tests/unit_tests/test_routes.py
+++ b/tests/unit_tests/test_routes.py
@@ -42,7 +42,7 @@ class TestRoutes(unittest.TestCase):
         region = 'eu-central-1'
         self.connection = boto3.resource('dynamodb', region)
         self.connection.create_table(
-            TableName='shorturl',
+            TableName='shortlinks_test',
             AttributeDefinitions=[
                 {
                     'AttributeName': 'url',
@@ -97,7 +97,7 @@ class TestRoutes(unittest.TestCase):
                 'WriteCapacityUnits': 123
             }
         )
-        self.table = self.connection.Table('shorturl')
+        self.table = self.connection.Table('shortlinks_test')
         for url in self.valid_urls_list:
             uuid = (create_url(self.table, url))
             self.uuid_to_url_dict[uuid] = url


### PR DESCRIPTION
Issue : 
In the code, shortlinks_id is used to describe the shortlinks identifier. The field in dynamodb was still shorturl (and its index, shortlinkID). To be consistent with the code, the field had to be renamed shortlinks_id, and the index ShortlinksIndex to be consistent with UrlIndex, the other index.

fix : 
changed the fields in accessers, and in tests. In addition, as the dynamodb table names have been decided to be shortlinks_dev/int/prod, the default value was changed, the readme was updated, and the table name in moto tests was changed to shortlinks_test to be consistent