### PR TITLE
Bugfix : forcing greenlet version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ boto3~=1.14.51
 logging-utilities==1.0.0
 flask==1.1.1
 gevent==20.6.2
+greenlet==0.4.16
 gunicorn==19.9.0
 PyYAML~=5.3.1
 moto~=1.3.16


### PR DESCRIPTION
Issue : greenlet version started messing up containers in service-shortlinks too. 

Fix : we enforce greenlet version to one compatible with the current gevent version used.