### PR TITLE
BGDIINF_SB-2027: Added Access-Control-Allow-Headers in responses

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -53,7 +53,7 @@ def add_generic_cors_header(response):
         response.headers.set('Access-Control-Allow-Origin', request.headers['Origin'])
     # Always add the allowed methods.
     response.headers.set(
-        'Access-Control-Allow-Methods', ','.join(get_registered_method(app, request.endpoint))
+        'Access-Control-Allow-Methods', ', '.join(get_registered_method(app, request.endpoint))
     )
     response.headers.set('Access-Control-Allow-Headers', '*')
     return response

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,6 +55,7 @@ def add_generic_cors_header(response):
     response.headers.set(
         'Access-Control-Allow-Methods', ','.join(get_registered_method(app, request.endpoint))
     )
+    response.headers.set('Access-Control-Allow-Headers', '*')
     return response
 
 

--- a/tests/unit_tests/base.py
+++ b/tests/unit_tests/base.py
@@ -107,7 +107,12 @@ class BaseShortlinkTestCase(unittest.TestCase):
         self.assertIn('Access-Control-Allow-Methods', response.headers)
         self.assertListEqual(
             sorted(expected_allowed_methods),
-            sorted(response.headers['Access-Control-Allow-Methods'].split(','))
+            sorted(
+                map(
+                    lambda m: m.strip(),
+                    response.headers['Access-Control-Allow-Methods'].split(',')
+                )
+            )
         )
         self.assertIn('Access-Control-Allow-Headers', response.headers)
         self.assertEqual(response.headers['Access-Control-Allow-Headers'], '*')

--- a/tests/unit_tests/base.py
+++ b/tests/unit_tests/base.py
@@ -109,3 +109,5 @@ class BaseShortlinkTestCase(unittest.TestCase):
             sorted(expected_allowed_methods),
             sorted(response.headers['Access-Control-Allow-Methods'].split(','))
         )
+        self.assertIn('Access-Control-Allow-Headers', response.headers)
+        self.assertEqual(response.headers['Access-Control-Allow-Headers'], '*')


### PR DESCRIPTION
This CORS header is required by Angular Frontends. For sake of
simplicity we allow every headers for the moment.

This PR state is currently deployed on DEV, @procrastinatio could you test if it now works with Angular ?