### PR TITLE
BGDIINF_SB-2046: Corrected the generic function get_registered_method()

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -3,4 +3,4 @@ AWS_SECRET_ACCESS_KEY=dummy-123
 AWS_ENDPOINT_URL=http://localhost:8080
 AWS_DEFAULT_REGION=eu-central-1
 AWS_DYNAMODB_TABLE_NAME=test-db
-ALLOWED_DOMAINS=.*
+ALLOWED_DOMAINS=.*localhost,.*admin\.ch,.*bgdi\.ch

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -64,7 +64,7 @@ def add_generic_cors_header(response):
         response.headers.set('Access-Control-Allow-Origin', request.headers['Origin'])
     # Always add the allowed methods.
     response.headers.set(
-        'Access-Control-Allow-Methods', ', '.join(get_registered_method(app, request.endpoint))
+        'Access-Control-Allow-Methods', ', '.join(get_registered_method(app, request.url_rule))
     )
     response.headers.set('Access-Control-Allow-Headers', '*')
     return response

--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -24,7 +24,7 @@ def init_logging():
     logging.config.dictConfig(config)
 
 
-def get_registered_method(app, endpoint):
+def get_registered_method(app, url_rule):
     '''Returns the list of registered method for the given endpoint'''
 
     # The list of registered method is taken from the werkzeug.routing.Rule. A Rule object
@@ -32,9 +32,11 @@ def get_registered_method(app, endpoint):
     # missing then all methods are allowed.
     # See https://werkzeug.palletsprojects.com/en/2.0.x/routing/#werkzeug.routing.Rule
     all_methods = ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'DELETE']
-    return list(
+    return set(
         chain.from_iterable([
-            r.methods if r.methods else all_methods for r in app.url_map.iter_rules(endpoint)
+            r.methods if r.methods else all_methods
+            for r in app.url_map.iter_rules()
+            if r.rule == str(url_rule)
         ])
     )
 


### PR DESCRIPTION
The allowed method in CORS header where not correct, the list contained
only the methods for the endpoint (methods registered by the python
route function) and not the methods registered to the path. 

Because the service did not have any function registered to the same
path, the bug did not have any consequence, but in order to be correct and
avoid copy paste mistake the function has been corrected.

Also added the ALLOWED_DOMAINS in .env.default in order to simplify the
e2e test with localhost.