### PR TITLE
Renamed the workflow templates

### DIFF
--- a/.github/workflows/pr-auto-semver.yml
+++ b/.github/workflows/pr-auto-semver.yml
@@ -1,4 +1,4 @@
-name: PR New SemVer Release Auto Title
+name: on-pr
 
 on:
   pull_request:

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,4 +1,4 @@
-name: Bump SemVer Version
+name: on-push
 
 on:
   push:


### PR DESCRIPTION
The main workflow file parameter `name` is used in the github PR check
section as prefix to display every actions. In order to keep this display
a bit cleaner and short we use a shorter name.

e.g changed such display:

`PR New SemVer Release Auto Title / pr-edit / Set PR title (pull_request)`
`PR New SemVer Release Auto Title / pr-edit / Set PR label (pull_request)`

to

`on-pr / pr-edit / Set PR title (pull_request)`
`on-pr / pr-edit / Set PR label (pull_request)`