### PR TITLE
BGDIINF_SB-2380: Added 'staging' in DB

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -4,3 +4,4 @@ AWS_ENDPOINT_URL=http://localhost:8080
 AWS_DEFAULT_REGION=eu-central-1
 AWS_DYNAMODB_TABLE_NAME=test-db
 ALLOWED_DOMAINS=.*localhost,.*admin\.ch,.*bgdi\.ch
+STAGING=local

--- a/.env.testing
+++ b/.env.testing
@@ -7,3 +7,5 @@ AWS_SESSION_TOKEN=testing
 # Fake regions will cause a crash when mocking.
 AWS_DEFAULT_REGION=us-east-1
 AWS_DYNAMODB_TABLE_NAME=test-db
+
+STAGING=test

--- a/app/helpers/urls.py
+++ b/app/helpers/urls.py
@@ -8,6 +8,7 @@ from boto3.dynamodb.conditions import Key
 from flask import abort
 
 from app.helpers.checks import check_and_get_shortlinks_id
+from app.settings import STAGING
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ def create_url(table, url):
                 'shortlinks_id': shortened_url,
                 'url': url,
                 'timestamp': time.strftime('%Y-%m-%d %X', now),
-                'epoch': str(time.gmtime())
+                'staging': STAGING
             }
         )
         logger.info("Exit create_url function with shortened url --> %s", shortened_url)

--- a/app/settings.py
+++ b/app/settings.py
@@ -22,3 +22,5 @@ AWS_ENDPOINT_URL = os.environ.get('AWS_ENDPOINT_URL', None)
 
 CACHE_CONTROL = os.getenv('CACHE_CONTROL', 'public, max-age=31536000')
 CACHE_CONTROL_4XX = os.getenv('CACHE_CONTROL_4XX', 'public, max-age=3600')
+
+STAGING = os.environ['STAGING']


### PR DESCRIPTION
This is needed to migrate into a new table (using shortlink_id as primary key).
This allow us to create an index based on staging and to use the timestamp
as sorted key and to then do an efficient query to get only the latest created
entries.