### PR TITLE
BGDIINF_SB-2380: Make sure that the created timestamp is consistent

### DIFF
--- a/app/helpers/dynamo_db.py
+++ b/app/helpers/dynamo_db.py
@@ -88,7 +88,7 @@ class DynamoDB():
         Returns:
             Table entry
         '''
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(timezone.utc).isoformat(timespec='milliseconds')
         collision_retry = 0
         while True:
             try:


### PR DESCRIPTION
By default datetime.isoformat() uses an automatic time specification and the
result might be with milliseconds or with microseconds or simply with seconds.

This is an issue on the DB side to do query from a given date where we can
do only simple text comparison. So in order to have a query to retrieve all
items from a specific timestamps all timestamps need to be exactly formatted.