### PR TITLE
PB-737: Fix CORS issues when working on localhost

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -3,5 +3,5 @@ AWS_SECRET_ACCESS_KEY=dummy123
 AWS_ENDPOINT_URL=http://localhost:8080
 AWS_DEFAULT_REGION=eu-central-1
 AWS_DYNAMODB_TABLE_NAME=test-db
-ALLOWED_DOMAINS=.*localhost((:[0-9]*)?|\/)?,.*admin\.ch,.*bgdi\.ch
+ALLOWED_DOMAINS=https?://localhost(:\d+)?(/.*)?,https://.*\.geo\.admin\.ch(/.*)?,https://.*\.bgdi\.ch(/.*)?
 STAGING=local

--- a/.env.default
+++ b/.env.default
@@ -3,5 +3,5 @@ AWS_SECRET_ACCESS_KEY=dummy123
 AWS_ENDPOINT_URL=http://localhost:8080
 AWS_DEFAULT_REGION=eu-central-1
 AWS_DYNAMODB_TABLE_NAME=test-db
-ALLOWED_DOMAINS=https?://localhost(:\d+)?(/.*)?,https://.*\.geo\.admin\.ch(/.*)?,https://.*\.bgdi\.ch(/.*)?
+ALLOWED_DOMAINS=localhost,.*\.geo\.admin\.ch,.*\.bgdi\.ch
 STAGING=local

--- a/.env.testing
+++ b/.env.testing
@@ -1,4 +1,4 @@
-ALLOWED_DOMAINS=.*\.geo\.admin\.ch,.*\.bgdi\.ch,http://localhost((:[0-9]*)?|\/)?
+ALLOWED_DOMAINS=https?://localhost(:\d+)?(/.*)?,https?://.*\.geo\.admin\.ch(/.*)?,https://.*\.bgdi\.ch(/.*)?
 AWS_ACCESS_KEY_ID=testing
 AWS_SECRET_ACCESS_KEY=testing
 AWS_SECURITY_TOKEN=testing

--- a/.env.testing
+++ b/.env.testing
@@ -1,4 +1,4 @@
-ALLOWED_DOMAINS=https?://localhost(:\d+)?(/.*)?,https?://.*\.geo\.admin\.ch(/.*)?,https://.*\.bgdi\.ch(/.*)?
+ALLOWED_DOMAINS=localhost,.*\.geo\.admin\.ch,.*\.bgdi\.ch
 AWS_ACCESS_KEY_ID=testing
 AWS_SECRET_ACCESS_KEY=testing
 AWS_SECURITY_TOKEN=testing

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,8 +12,8 @@ from flask import url_for
 
 from app.helpers.utils import get_redirect_param
 from app.helpers.utils import get_registered_method
+from app.helpers.utils import is_domain_allowed
 from app.helpers.utils import make_error_msg
-from app.settings import ALLOWED_DOMAINS_PATTERN
 from app.settings import CACHE_CONTROL
 from app.settings import CACHE_CONTROL_4XX
 
@@ -23,10 +23,6 @@ logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 app.config.from_mapping({"TRAP_HTTP_EXCEPTIONS": True})
-
-
-def is_domain_allowed(domain):
-    return re.fullmatch(ALLOWED_DOMAINS_PATTERN, domain) is not None
 
 
 @app.before_request

--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -4,7 +4,6 @@ import os
 import re
 from itertools import chain
 from pathlib import Path
-from urllib.parse import urlparse
 
 import validators
 import yaml
@@ -113,8 +112,12 @@ def get_url():
             f"The url given as parameter was too long. (limit is 2046 "
             f"characters, {len(url)} given)"
         )
-    if not re.fullmatch(ALLOWED_DOMAINS_PATTERN, urlparse(url).netloc):
-        logger.error('URL(%s) given as a parameter is not allowed', url)
+    if not is_domain_allowed(url):
+        logger.error(
+            'URL(%s) given as a parameter is not allowed, test pattern %s',
+            url,
+            ALLOWED_DOMAINS_PATTERN
+        )
         abort(400, 'URL given as a parameter is not allowed.')
 
     return url
@@ -132,3 +135,9 @@ def strtobool(value) -> bool:
     if value in ('n', 'no', 'f', 'false', 'off', '0'):
         return False
     raise ValueError(f"invalid truth value \'{value}\'")
+
+
+def is_domain_allowed(url):
+    """Check if the url contain a domain that is allowed
+    """
+    return re.fullmatch(ALLOWED_DOMAINS_PATTERN, url) is not None

--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -4,6 +4,7 @@ import os
 import re
 from itertools import chain
 from pathlib import Path
+from urllib.parse import urlparse
 
 import validators
 import yaml
@@ -140,4 +141,7 @@ def strtobool(value) -> bool:
 def is_domain_allowed(url):
     """Check if the url contain a domain that is allowed
     """
-    return re.fullmatch(ALLOWED_DOMAINS_PATTERN, url) is not None
+    domain = urlparse(url).hostname
+    if domain:
+        return re.fullmatch(ALLOWED_DOMAINS_PATTERN, domain) is not None
+    return False

--- a/tests/unit_tests/test_routes.py
+++ b/tests/unit_tests/test_routes.py
@@ -182,7 +182,7 @@ class TestRoutes(BaseShortlinkTestCase):
         for short_id, url in self.uuid_to_url_dict.items():
             response = self.app.get(url_for('get_shortlink', shortlink_id=short_id))
             self.assertEqual(response.status_code, 301)
-            self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], origin_pattern=r"^\*$")
+            self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], all_origin=True)
             self.assertIn('Cache-Control', response.headers)
             self.assertIn('max-age=', response.headers['Cache-Control'])
             self.assertEqual(response.content_type, "text/html; charset=utf-8")
@@ -196,7 +196,7 @@ class TestRoutes(BaseShortlinkTestCase):
                 headers={"Origin": "www.example.com"}
             )
             self.assertEqual(response.status_code, 301)
-            self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], origin_pattern=r"^\*$")
+            self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], all_origin=True)
             self.assertIn('Cache-Control', response.headers)
             self.assertIn('max-age=', response.headers['Cache-Control'])
             self.assertEqual(response.content_type, "text/html; charset=utf-8")
@@ -239,7 +239,7 @@ class TestRoutes(BaseShortlinkTestCase):
             }
         }
         self.assertEqual(response.status_code, 404)
-        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], origin_pattern=r"^\*$")
+        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], all_origin=True)
         self.assertIn('Cache-Control', response.headers)
         self.assertIn('max-age=3600', response.headers['Cache-Control'])
         self.assertIn('application/json', response.content_type)
@@ -393,11 +393,11 @@ class TestRoutes(BaseShortlinkTestCase):
             headers=headers
         )
         self.assertEqual(response.status_code, 301)
-        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], origin_pattern=r"^\*$")
+        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], all_origin=True)
 
         response = self.app.get(url_for('get_shortlink', shortlink_id=short_id), headers=headers)
         self.assertEqual(response.status_code, 301)
-        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], origin_pattern=r"^\*$")
+        self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], all_origin=True)
 
     @params(
         {'Origin': 'https://map.geo.admin.ch'},

--- a/tests/unit_tests/test_routes.py
+++ b/tests/unit_tests/test_routes.py
@@ -18,7 +18,7 @@ class TestRoutes(BaseShortlinkTestCase):
 
     def test_checker_ok(self):
         # checker
-        response = self.app.get(url_for('checker'), headers={"Origin": "map.geo.admin.ch"})
+        response = self.app.get(url_for('checker'), headers={"Origin": "https://map.geo.admin.ch"})
         self.assertEqual(response.status_code, 200)
         self.assertNotIn('Cache-Control', response.headers)
         self.assertEqual(response.content_type, "application/json; charset=utf-8")
@@ -27,7 +27,9 @@ class TestRoutes(BaseShortlinkTestCase):
     def test_create_shortlink_ok(self):
         url = "https://map.geo.admin.ch/#/map?lang=en&center=2647850.83,1120124.2&z=1.812&bgLayer=ch.swisstopo.pixelkarte-farbe&top"  # pylint: disable=line-too-long
         response = self.app.post(
-            url_for('create_shortlink'), json={"url": url}, headers={"Origin": "map.geo.admin.ch"}
+            url_for('create_shortlink'),
+            json={"url": url},
+            headers={"Origin": "https://map.geo.admin.ch"}
         )
         self.assertEqual(response.status_code, 201)
         self.assertCors(response, ['POST', 'OPTIONS'])
@@ -49,7 +51,9 @@ class TestRoutes(BaseShortlinkTestCase):
         )
         # Check that second call returns 200 and the same short url
         response = self.app.post(
-            url_for('create_shortlink'), json={"url": url}, headers={"Origin": "map.geo.admin.ch"}
+            url_for('create_shortlink'),
+            json={"url": url},
+            headers={"Origin": "https://map.geo.admin.ch"}
         )
         self.assertEqual(response.status_code, 200)
         self.assertCors(response, ['POST', 'OPTIONS'])
@@ -59,7 +63,7 @@ class TestRoutes(BaseShortlinkTestCase):
 
     def test_create_shortlink_no_json(self):
         response = self.app.post(
-            url_for('create_shortlink'), headers={"Origin": "map.geo.admin.ch"}
+            url_for('create_shortlink'), headers={"Origin": "https://map.geo.admin.ch"}
         )
         self.assertEqual(415, response.status_code)
         self.assertCors(response, ['POST', 'OPTIONS'])
@@ -77,7 +81,7 @@ class TestRoutes(BaseShortlinkTestCase):
 
     def test_create_shortlink_no_url(self):
         response = self.app.post(
-            url_for('create_shortlink'), json={}, headers={"Origin": "map.geo.admin.ch"}
+            url_for('create_shortlink'), json={}, headers={"Origin": "https://map.geo.admin.ch"}
         )
         self.assertEqual(400, response.status_code)
         self.assertCors(response, ['POST', 'OPTIONS'])
@@ -97,7 +101,7 @@ class TestRoutes(BaseShortlinkTestCase):
         response = self.app.post(
             url_for('create_shortlink'),
             json={"url": f"{wrong_url}"},
-            headers={"Origin": "map.geo.admin.ch"}
+            headers={"Origin": "https://map.geo.admin.ch"}
         )
         self.assertEqual(response.status_code, 400)
         self.assertCors(response, ['POST', 'OPTIONS'])
@@ -116,7 +120,7 @@ class TestRoutes(BaseShortlinkTestCase):
         response = self.app.post(
             url_for('create_shortlink'),
             json={"url": "https://non-allowed.hostname.ch/test"},
-            headers={"Origin": "map.geo.admin.ch"}
+            headers={"Origin": "https://map.geo.admin.ch"}
         )
         self.assertEqual(response.status_code, 400)
         self.assertCors(response, ['POST', 'OPTIONS'])
@@ -135,7 +139,7 @@ class TestRoutes(BaseShortlinkTestCase):
         response = self.app.post(
             url_for('create_shortlink'),
             json={"url": "https://map.geo.admin.ch.non-allowed.hostname.ch/test"},
-            headers={"Origin": "map.geo.admin.ch"}
+            headers={"Origin": "https://map.geo.admin.ch"}
         )
         self.assertEqual(response.status_code, 400)
         self.assertCors(response, ['POST', 'OPTIONS'])
@@ -156,7 +160,7 @@ class TestRoutes(BaseShortlinkTestCase):
             url_for('create_shortlink'),
             json={"url": url},
             content_type="application/json",
-            headers={"Origin": "map.geo.admin.ch"}
+            headers={"Origin": "https://map.geo.admin.ch"}
         )
         self.assertEqual(response.status_code, 400)
         self.assertCors(response, ['POST', 'OPTIONS'])
@@ -204,7 +208,7 @@ class TestRoutes(BaseShortlinkTestCase):
                 url_for('get_shortlink', shortlink_id=short_id),
                 query_string={'redirect': 'banana'},
                 content_type="text/html",
-                headers={"Origin": "map.geo.admin.ch"}
+                headers={"Origin": "https://map.geo.admin.ch"}
             )
             expected_json = {
                 'success': False,
@@ -226,7 +230,7 @@ class TestRoutes(BaseShortlinkTestCase):
     def test_redirect_shortlink_url_not_found(self):
         response = self.app.get(
             url_for('get_shortlink', shortlink_id='nonexistent'),
-            headers={"Origin": "map.geo.admin.ch"}
+            headers={"Origin": "https://map.geo.admin.ch"}
         )
         expected_json = {
             'success': False,
@@ -246,7 +250,7 @@ class TestRoutes(BaseShortlinkTestCase):
             response = self.app.get(
                 url_for('get_shortlink', shortlink_id=short_id),
                 query_string={'redirect': 'false'},
-                headers={"Origin": "map.geo.admin.ch"}
+                headers={"Origin": "https://map.geo.admin.ch"}
             )
             self.assertEqual(response.status_code, 200)
             self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'])
@@ -262,7 +266,7 @@ class TestRoutes(BaseShortlinkTestCase):
             response = self.app.get(
                 url_for('get_shortlink', shortlink_id=short_id),
                 query_string={'redirect': 'false'},
-                headers={"Origin": "map.geo.admin.ch"}
+                headers={"Origin": "https://map.geo.admin.ch"}
             )
             self.assertEqual(response.status_code, 200)
             self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'])
@@ -277,7 +281,7 @@ class TestRoutes(BaseShortlinkTestCase):
         response = self.app.get(
             url_for('get_shortlink', shortlink_id='nonexistent'),
             query_string={'redirect': 'false'},
-            headers={"Origin": "map.geo.admin.ch"}
+            headers={"Origin": "https://map.geo.admin.ch"}
         )
         self.assertEqual(response.status_code, 404)
         self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'])
@@ -325,12 +329,12 @@ class TestRoutes(BaseShortlinkTestCase):
         )
 
     @params(
-        {'Origin': 'map.geo.admin.ch'},
+        {'Origin': 'https://map.geo.admin.ch'},
         {
-            'Origin': 'map.geo.admin.ch', 'Sec-Fetch-Site': 'same-site'
+            'Origin': 'https://map.geo.admin.ch', 'Sec-Fetch-Site': 'same-site'
         },
         {
-            'Origin': 's.geo.admin.ch', 'Sec-Fetch-Site': 'same-origin'
+            'Origin': 'https://s.geo.admin.ch', 'Sec-Fetch-Site': 'same-origin'
         },
         {
             'Origin': 'http://localhost', 'Sec-Fetch-Site': 'cross-site'
@@ -396,12 +400,12 @@ class TestRoutes(BaseShortlinkTestCase):
         self.assertCors(response, ['GET', 'HEAD', 'OPTIONS'], origin_pattern=r"^\*$")
 
     @params(
-        {'Origin': 'map.geo.admin.ch'},
+        {'Origin': 'https://map.geo.admin.ch'},
         {
-            'Origin': 'map.geo.admin.ch', 'Sec-Fetch-Site': 'same-site'
+            'Origin': 'https://map.geo.admin.ch', 'Sec-Fetch-Site': 'same-site'
         },
         {
-            'Origin': 's.geo.admin.ch', 'Sec-Fetch-Site': 'same-origin'
+            'Origin': 'https://s.geo.admin.ch', 'Sec-Fetch-Site': 'same-origin'
         },
         {
             'Origin': 'http://localhost', 'Sec-Fetch-Site': 'cross-site'


### PR DESCRIPTION
Previous PR #66 was too restrictive has it blocked localhost on the DEV staging
which is needed to develop the web-mapviewer.

The main issue was that the ALLOWED_DOMAINS config was used for CORS and for
URL parameter check, but in the code the logic to validate CORS and url parameter
differ, due to this it was not possible anymore to set a ALLOWED_DOMAINS value
that would allow localhost as CORS and or as url parameter. The url parameter
check wanted to have a regex to exactly match the host name without the path,
while CORS did check the full url.

Now the code has been simplified and we use the same function/logic to test url
and CORS, using the full url. Note that ORIGIN and REFERER header based on the
documentation should always has the scheme http:// or https://. Referer might
have a path or not.

So now the ALLOWED_DOMAINS must be a pattern that match a full URL not only part
of it.

Together with https://github.com/geoadmin/infra-kubernetes/pull/629 it fix local development of web-mapviewer